### PR TITLE
memory: allow domain zero memory policy to be queried

### DIFF
--- a/memory/memory_interface.ml
+++ b/memory/memory_interface.ml
@@ -49,3 +49,9 @@ external get_host_reserved_memory: debug_info -> int64 = ""
 
 external get_host_initial_free_memory: debug_info -> int64 = ""
 
+type domain_zero_policy =
+   | Fixed_size of int64 (** it will never be ballooned *)
+   | Auto_balloon of int64 * int64 (** it will auto-balloon over a range *)
+
+external get_domain_zero_policy: debug_info -> domain_zero_policy = ""
+


### PR DESCRIPTION
Now that squeezed supports two different domain zero memory policies,
it is useful for xapi to be able to find out which policy is in effect
so it can populate the domain 0 VM fields correctly.

The two policies are:

 Fixed_size x
    -- domain zero will always occupy x bytes: this is the default
       XenServer iso configuration
 Auto_balloon (low, high)
    -- domain zero will be allowed to balloon between low and high:
       this is a likely configuration for a development environment

Signed-off-by: David Scott dave.scott@eu.citrix.com
