### PR TITLE
rrd_client: bypass the message switch

### DIFF
--- a/rrd/rrd_client.ml
+++ b/rrd/rrd_client.ml
@@ -32,7 +32,8 @@ module Client = Rrd_interface.Client(struct
   let rpc call =
     retry_econnrefused
       (fun () ->
-        if !use_switch
+        (* TODO: the message switch doesn't handle raw HTTP very well *)
+        if (* !use_switch *) false
         then json_switch_rpc !queue_name call
         else xml_http_rpc
           ~srcstr:(get_user_agent ())


### PR DESCRIPTION
xcp-rrdd is not yet message-switch aware. Therefore all users
should continue to use the Unix domain sockets for now.

Signed-off-by: David Scott dave.scott@citrix.com
